### PR TITLE
feat(voting-api): use voters balances for calculating voting statistics

### DIFF
--- a/packages/voting-api/src/controllers/statistics.ts
+++ b/packages/voting-api/src/controllers/statistics.ts
@@ -1,8 +1,10 @@
 import { Controller } from "@arkecosystem/core-api";
 import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { Utils } from "@arkecosystem/crypto";
 import Hapi from "@hapi/hapi";
 import { Indexers } from "@protokol/voting-transactions";
 
+import { VotingStatusEnum } from "../enums";
 import { StatisticsResource } from "../resources/statistics";
 
 @Container.injectable()
@@ -10,6 +12,9 @@ export class StatisticsController extends Controller {
 	@Container.inject(Container.Identifiers.WalletRepository)
 	@Container.tagged("state", "blockchain")
 	private readonly walletRepository!: Contracts.State.WalletRepository;
+
+	@Container.inject(Container.Identifiers.StateStore)
+	protected readonly stateStore!: Contracts.State.StateStore;
 
 	public async statistics(request: Hapi.Request): Promise<any> {
 		const proposedWallet = this.walletRepository.findByIndex(
@@ -19,12 +24,34 @@ export class StatisticsController extends Controller {
 
 		const proposedWalletData = proposedWallet.getAttribute("voting.proposal");
 		const proposedData = proposedWalletData[request.params.id];
+		const { blockHeight } = proposedData.proposal.duration;
+
+		let agree: { publicKey: string; balance: Utils.BigNumber }[];
+		let disagree: { publicKey: string; balance: Utils.BigNumber }[];
+		let status: VotingStatusEnum;
+		if (blockHeight > this.stateStore.getLastBlock().data.height) {
+			agree = proposedData.agree.map((publicKey) => ({
+				publicKey,
+				balance: this.walletRepository.findByPublicKey(publicKey).getBalance(),
+			}));
+			disagree = proposedData.disagree.map((publicKey) => ({
+				publicKey,
+				balance: this.walletRepository.findByPublicKey(publicKey).getBalance(),
+			}));
+			status = VotingStatusEnum.IN_PROGRESS;
+		} else {
+			// TODO fetch from database
+			agree = proposedData.agree.map((publicKey) => ({ publicKey, balance: Utils.BigNumber.ONE }));
+			disagree = proposedData.disagree.map((publicKey) => ({ publicKey, balance: Utils.BigNumber.ONE }));
+			status = VotingStatusEnum.FINISHED;
+		}
 
 		return this.respondWithResource(
 			{
 				publicKey: proposedWallet.getPublicKey(),
 				address: proposedWallet.getAddress(),
-				voters: proposedData,
+				voters: { agree, disagree },
+				status,
 			},
 			StatisticsResource,
 		);

--- a/packages/voting-api/src/enums.ts
+++ b/packages/voting-api/src/enums.ts
@@ -1,0 +1,4 @@
+export enum VotingStatusEnum {
+	IN_PROGRESS = "VOTING_IN_PROGRESS",
+	FINISHED = "VOTING_FINISHED",
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Use voter's balances when calculating voting statistics.
Added status of the voting proposal to the response.

### Why are these changes necessary?
To correctly display voting statistics based on weighted voter's balances instead of assuming that all voters weight is 1.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->

